### PR TITLE
Update bot logic with localization and webapp integration

### DIFF
--- a/CHANGES_SUMMARY.md
+++ b/CHANGES_SUMMARY.md
@@ -1,0 +1,65 @@
+# Bot Updates Summary
+
+## Changes Implemented
+
+### 1. Updated Welcome Message (/start command)
+**Location:** `bot/bot.js` lines 21-44
+
+**Changes:**
+- Added localization support for Russian (ru) and English (default for others)
+- Russian message: "Привет! Добро пожаловать в Квизы с призами. Проходи квизы каждую неделю и участвуй в розыгрышах. Скорее начинай!"
+- English message: "Hey, welcome to Quizzes with Prizes. Complete the quizzes every week and participate in the Giveaways. Open app to start"
+- Added inline keyboard button that opens `t.me/tgquizprizebot/app`
+- Button text is also localized: "🎮 Открыть приложение" (RU) / "🎮 Open App" (EN)
+
+### 2. Removed Reply Keyboards
+**Locations:** 
+- `bot/bot.js` line 36-41 (removed from /start command)
+- `bot/bot.js` line 80-83 (removed force_reply from /createcampaign)
+
+**Changes:**
+- Removed the persistent reply keyboard that showed command buttons
+- Removed force_reply from campaign creation flow
+- Users now interact through inline keyboards and direct commands only
+
+### 3. Updated Campaign Link Generation
+**Location:** `server.js` lines 260-272
+
+**Changes:**
+- Campaign links now use the format: `t.me/tgquizprizebot/app?startapp={campaignID}`
+- Removed base64 encoding of campaign ID
+- Campaign ID is now passed directly as the startapp parameter
+- This allows the link to directly open the webapp with the campaign identifier
+
+**Additional Updates:**
+- Updated the success message in `bot/bot.js` (lines 192-214) to clarify that the link opens the webapp directly
+- Updated help text to reflect the new functionality
+
+## How It Works Now
+
+1. **Start Command**: When users send `/start`, they receive a localized welcome message with a button to open the quiz webapp directly.
+
+2. **Campaign Creation**: The `/createcampaign` command now:
+   - Asks for a campaign ID (without force reply)
+   - Generates a link in format: `t.me/tgquizprizebot/app?startapp={campaignID}`
+   - The campaign ID is passed directly without encoding
+
+3. **User Experience**: 
+   - No persistent keyboards cluttering the interface
+   - Clean inline buttons for navigation
+   - Direct webapp links with campaign tracking
+
+## Testing
+
+A test script has been created at `test_changes.js` to verify the campaign link generation works correctly.
+
+To test:
+1. Start the server: `node server.js`
+2. Run the test: `node test_changes.js`
+
+## Files Modified
+
+1. `/workspace/tgquizprizebot/bot/bot.js` - Main bot logic updates
+2. `/workspace/tgquizprizebot/server.js` - Campaign link generation update
+3. `/workspace/tgquizprizebot/test_changes.js` - Test script (new file)
+4. `/workspace/tgquizprizebot/CHANGES_SUMMARY.md` - This summary (new file)

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -21,23 +21,28 @@ const userStates = new Map();
 // Command: /start
 bot.onText(/\/start/, (msg) => {
   const chatId = msg.chat.id;
-  const firstName = msg.from.first_name || 'User';
+  const userLanguage = msg.from.language_code;
+  
+  // Determine if user locale is Russian
+  const isRussian = userLanguage && userLanguage.toLowerCase().startsWith('ru');
+  
+  // Localized welcome messages
+  const welcomeMessage = isRussian 
+    ? "Привет! Добро пожаловать в Квизы с призами. Проходи квизы каждую неделю и участвуй в розыгрышах. Скорее начинай!"
+    : "Hey, welcome to Quizzes with Prizes. Complete the quizzes every week and participate in the Giveaways. Open app to start";
+  
+  const buttonText = isRussian ? "🎮 Открыть приложение" : "🎮 Open App";
   
   bot.sendMessage(chatId, 
-    `👋 Welcome ${firstName}!\n\n` +
-    `I'm the Quiz Prize Bot! Here's what I can do:\n\n` +
-    `🎯 /createcampaign - Create a campaign link\n` +
-    `📊 /campaigns - List all campaigns\n` +
-    `❓ /help - Show this help message\n\n` +
-    `Ready to create engaging quiz campaigns? Let's get started!`,
+    welcomeMessage,
     {
       parse_mode: 'HTML',
       reply_markup: {
-        keyboard: [
-          ['/createcampaign', '/campaigns'],
-          ['/help']
-        ],
-        resize_keyboard: true
+        inline_keyboard: [
+          [
+            { text: buttonText, url: 't.me/tgquizprizebot/app' }
+          ]
+        ]
       }
     }
   );
@@ -54,7 +59,7 @@ bot.onText(/\/help/, (msg) => {
     `<b>/campaigns</b>\n` +
     `View all existing campaign IDs from the database.\n\n` +
     `<b>/start</b>\n` +
-    `Show the welcome message and available commands.\n\n` +
+    `Show the welcome message and open the quiz app.\n\n` +
     `<b>How campaigns work:</b>\n` +
     `1. Create a campaign with a unique ID\n` +
     `2. Share the generated link with participants\n` +
@@ -76,11 +81,7 @@ bot.onText(/\/createcampaign/, (msg) => {
     `Please enter your campaign ID (e.g., <code>summer2024</code>, <code>blackfriday</code>, etc.):\n\n` +
     `<i>The campaign ID should be unique and memorable.</i>`,
     { 
-      parse_mode: 'HTML',
-      reply_markup: {
-        force_reply: true,
-        input_field_placeholder: 'Enter campaign ID...'
-      }
+      parse_mode: 'HTML'
     }
   );
 });
@@ -192,9 +193,9 @@ bot.on('message', async (msg) => {
         bot.sendMessage(chatId,
           `✅ <b>Campaign Link Created!</b>\n\n` +
           `<b>Campaign ID:</b> <code>${campaignId}</code>\n\n` +
-          `<b>Your campaign link:</b>\n` +
+          `<b>Your webapp campaign link:</b>\n` +
           `<code>${response.data.url}</code>\n\n` +
-          `📋 <i>Click the link above to copy it</i>\n\n` +
+          `📋 <i>This link will directly open the quiz webapp with your campaign ID</i>\n\n` +
           `Share this link with your participants to track their quiz results under this campaign.`,
           { 
             parse_mode: 'HTML',

--- a/server.js
+++ b/server.js
@@ -265,8 +265,8 @@ app.get('/api/campaign-link', (req, res) => {
     return res.status(400).json({ error: 'campaign_id is required' });
   }
 
-  const encodedCampaignId = Buffer.from(campaign_id).toString('base64');
-  const url = `t.me/tgquizprizebot/app?startapp=${encodedCampaignId}`;
+  // Use campaign_id directly in the URL without encoding
+  const url = `t.me/tgquizprizebot/app?startapp=${campaign_id}`;
   
   res.json({ url });
 });


### PR DESCRIPTION
- Add localized welcome messages (RU/EN) in /start command
- Add webapp button to directly open t.me/tgquizprizebot/app
- Remove all reply keyboards for cleaner UX
- Update campaign link generation to use direct campaignID (no base64)
- Campaign links now format: t.me/tgquizprizebot/app?startapp={campaignID}
- Improve user experience with inline keyboards only